### PR TITLE
Added method to delete specific table entry rather than table.delete()

### DIFF
--- a/delete_test.py
+++ b/delete_test.py
@@ -1,0 +1,65 @@
+import pytest
+import mro
+import mro.foreign_keys
+import connection as con
+
+@pytest.fixture(scope="module")
+def connection(request):
+    connection = con.connect()
+    request.addfinalizer(mro.disconnect)
+
+    cursor = connection.cursor()
+
+    con.drop_tables()
+
+    cursor.execute("""create table table1 (
+    id serial unique, 
+    name varchar(20) not null,
+    value varchar(20),
+    primary key (id, name)
+    );""")
+
+    connection.commit()
+
+    create_test_data(connection)
+
+    connection.close()
+
+    mro.load_database(lambda: con.connect())
+
+    return connection
+
+def create_test_data(connection):
+
+    cursor = connection.cursor()
+    num_table1 = 2
+    for i in range(1,num_table1+1):
+        cursor.execute("insert into table1 (name) values (%s)", ('table1_{}'.format(i),))
+        for j in range(1,4):
+            cursor.execute("insert into table2 (name, table1_id) values (%s,%s)", ('table2_{}_{}'.format(i, j), i))
+
+    # edge cases
+    cursor.execute("insert into table2 (name, table1_id) values (%s,%s)", ('table2_None', None))
+    cursor.execute("insert into table1 (name) values (%s)", ('table1_None',))
+
+    connection.commit()
+
+class TestUpdates(object):
+
+    def test_delete(self, connection):
+
+        new_to_delete_entry = mro.table1(name='Test34', value='exists')
+        new_do_not_delete_entry = mro.table1(name='Test35', value='exists')
+        table_entries_length = len(mro.table1.select())
+        new_to_delete_entry = mro.table1.select_one("name='Test34'")
+        assert new_to_delete_entry is not None
+        new_to_delete_entry.delete()
+        new_to_delete_entry = mro.table1.select_one("name='Test34'")
+        assert new_to_delete_entry is None
+        new_do_not_delete_entry = mro.table1.select_one("name='Test35'")
+        assert new_do_not_delete_entry is not None
+        assert len(mro.table1.select()) == table_entries_length - 1
+
+
+if __name__ == '__main__':
+    pytest.main([__file__])

--- a/delete_test.py
+++ b/delete_test.py
@@ -35,8 +35,6 @@ def create_test_data(connection):
     num_table1 = 2
     for i in range(1,num_table1+1):
         cursor.execute("insert into table1 (name) values (%s)", ('table1_{}'.format(i),))
-        for j in range(1,4):
-            cursor.execute("insert into table2 (name, table1_id) values (%s,%s)", ('table2_{}_{}'.format(i, j), i))
 
     connection.commit()
 

--- a/delete_test.py
+++ b/delete_test.py
@@ -38,13 +38,9 @@ def create_test_data(connection):
         for j in range(1,4):
             cursor.execute("insert into table2 (name, table1_id) values (%s,%s)", ('table2_{}_{}'.format(i, j), i))
 
-    # edge cases
-    cursor.execute("insert into table2 (name, table1_id) values (%s,%s)", ('table2_None', None))
-    cursor.execute("insert into table1 (name) values (%s)", ('table1_None',))
-
     connection.commit()
 
-class TestUpdates(object):
+class TestDelete(object):
 
     def test_delete(self, connection):
 

--- a/mro/__init__.py
+++ b/mro/__init__.py
@@ -235,8 +235,15 @@ def _create_classes(tables):
                         self.__dict__[k] = v
                     return self
 
+            def delete_function(self):
+                primary_key_columns = self.__class__._primary_key_columns
+                primary_key_column_values = [self.__dict__[c] for c in primary_key_columns]
+                clause = " and ".join([c + '=%s' for c in primary_key_columns])
+                super(self.__class__, self).delete(clause, *primary_key_column_values)
+
             attrib_dict = {'__init__': init_function,
-                           'update': update_function}
+                           'update': update_function,
+                           'delete': delete_function}
             table_class = type(name, (mro.table.table,), attrib_dict)
             return table_class
         dynamic_table_class = create_table_class(table_name, table_columns)

--- a/mro/__init__.py
+++ b/mro/__init__.py
@@ -193,6 +193,29 @@ def _create_classes(tables):
         foreign_key_targets = table_data['foreign_key_targets']
 
         def create_table_class(name, columns):
+            def update_function(self, **kwargs):
+                primary_key_columns = self.__class__._primary_key_columns
+                primary_key_column_values = [self.__dict__[c] for c in primary_key_columns]
+
+                super(self.__class__, self).update(primary_key_columns, primary_key_column_values, **kwargs)
+                for column in columns:
+                    if column['column_name'] in kwargs:
+                        kwarg_for_column = kwargs.get(column['column_name'])
+                        if column['data_type'] in ["json", "jsonb"] and type(kwarg_for_column) == str:
+                            kwarg_for_column = json.loads(kwarg_for_column)
+                        column_metadata = self.__class__.__dict__[column['column_name']]
+                        kwargs[column['column_name']] = column['conversion_function'](column_metadata, self, kwarg_for_column)
+                with mro.table.disable_insert():
+                    for k, v in kwargs.items():
+                        self.__dict__[k] = v
+                    return self
+
+            def delete_function(self, *format_args):
+                primary_key_columns = self.__class__._primary_key_columns
+                primary_key_column_values = [self.__dict__[c] for c in primary_key_columns]
+                clause = " and ".join([c + '=%s' for c in primary_key_columns])
+                super(self.__class__, self).delete(clause, *primary_key_column_values)
+
             def init_function(self, **kwargs):
                 for column in columns:
                     self.__dict__[column['column_name']] = column['column_default']
@@ -218,34 +241,14 @@ def _create_classes(tables):
                     for c in self.__class__._get_value_on_insert_columns:
                         self.__dict__[c] = obj.__dict__[c]
 
-            def update_function(self, **kwargs):
-                primary_key_columns = self.__class__._primary_key_columns
-                primary_key_column_values = [self.__dict__[c] for c in primary_key_columns]
+                # Overriding the table wide update and delete methods so we can continue to use table methods on class objects.
+                self.update = update_function
+                self.delete = delete_function
 
-                super(self.__class__, self).update(primary_key_columns, primary_key_column_values, **kwargs)
-                for column in columns:
-                    if column['column_name'] in kwargs:
-                        kwarg_for_column = kwargs.get(column['column_name'])
-                        if column['data_type'] in ["json", "jsonb"] and type(kwarg_for_column) == str:
-                            kwarg_for_column = json.loads(kwarg_for_column)
-                        column_metadata = self.__class__.__dict__[column['column_name']]
-                        kwargs[column['column_name']] = column['conversion_function'](column_metadata, self, kwarg_for_column)
-                with mro.table.disable_insert():
-                    for k, v in kwargs.items():
-                        self.__dict__[k] = v
-                    return self
-
-            def delete_function(self):
-                primary_key_columns = self.__class__._primary_key_columns
-                primary_key_column_values = [self.__dict__[c] for c in primary_key_columns]
-                clause = " and ".join([c + '=%s' for c in primary_key_columns])
-                super(self.__class__, self).delete(clause, *primary_key_column_values)
-
-            attrib_dict = {'__init__': init_function,
-                           'update': update_function,
-                           'delete': delete_function}
+            attrib_dict = {'__init__': init_function}
             table_class = type(name, (mro.table.table,), attrib_dict)
             return table_class
+
         dynamic_table_class = create_table_class(table_name, table_columns)
 
         for column in table_columns:


### PR DESCRIPTION
Changes the behaviour of the delete method when called from a specific table entry.
Currently running
```
p = mro.table.select_one("name='TestName'")
p.delete()
```
is equivalent to 
```
p.table.delete()
```

This adds a delete method to database entry custom classes in the same way the update or create was done, which generates a clause based on the entry's primary keys to only delete this specific entry.
eg, if the table has primary keys `id` and `name`;
```
p = mro.table.select_one("name='TestName'")
p.delete()
```
is now equivalent to;
```
p = mro.table.select_one("name='TestName'")
mro.table.delete('id=%s and name=%s', 12, 'TestName')
```